### PR TITLE
Fix: LT-18377 Build and use a 64bit version in ICU

### DIFF
--- a/nugetpackage/build/icu4c.proj
+++ b/nugetpackage/build/icu4c.proj
@@ -18,9 +18,9 @@
 		<PlatformToBuild Include="x86">
 			<Platform>Win32</Platform>
 		</PlatformToBuild>
-		<!--<PlatformToBuild Include="x64">
+		<PlatformToBuild Include="x64">
 			<Platform>x64</Platform>
-		</PlatformToBuild>-->
+		</PlatformToBuild>
 	</ItemGroup>
 
 	<Target Name="Build">

--- a/source/samples/cal/cal.vcxproj
+++ b/source/samples/cal/cal.vcxproj
@@ -150,7 +150,7 @@
       <AdditionalDependencies>icuuc.lib;icuin.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>.\x64\Release/cal.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>../../../lib64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>../../../lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <ProgramDatabaseFile>.\x64\Release/cal.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>
       <RandomizedBaseAddress>false</RandomizedBaseAddress>
@@ -231,7 +231,7 @@
       <AdditionalDependencies>icuucd.lib;icuind.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>.\x64\Debug/cal.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>../../../lib64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>../../../lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ProgramDatabaseFile>.\x64\Debug/cal.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>

--- a/source/samples/date/date.vcxproj
+++ b/source/samples/date/date.vcxproj
@@ -150,7 +150,7 @@
       <AdditionalDependencies>icuuc.lib;icuin.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>.\x64\Release/date.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>../../../lib64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>../../../lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <ProgramDatabaseFile>.\x64\Release/date.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>
       <RandomizedBaseAddress>false</RandomizedBaseAddress>
@@ -229,7 +229,7 @@
       <AdditionalDependencies>icuucd.lib;icuind.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>.\x64\Debug/date.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>../../../lib64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>../../../lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ProgramDatabaseFile>.\x64\Debug/date.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>


### PR DESCRIPTION
* Changed the cal vcxproj file removed Lib64 folder mentioned
* Changed the date vcxproj file removed Lib64 folder mentioned
* UnCommented the PlatformBuild for x64 bit

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/icu4c/18)
<!-- Reviewable:end -->
